### PR TITLE
I2368 

### DIFF
--- a/Spanner/src/Session/CacheSessionPool.php
+++ b/Spanner/src/Session/CacheSessionPool.php
@@ -604,14 +604,14 @@ class CacheSessionPool implements SessionPoolInterface
     }
 
     /**
-     * Gets the next session in the queue, clearing out any which are expired.
+     * Gets the last session in the queue, clearing out any which are expired.
      *
      * @param array $data
      * @return array|null
      */
     private function getSession(array &$data)
     {
-        $session = array_shift($data['queue']);
+        $session = array_pop($data['queue']);
 
         if ($session) {
             if ($session['expiration'] - self::DURATION_ONE_MINUTE < $this->time()) {

--- a/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
+++ b/Spanner/tests/Unit/Session/CacheSessionPoolTest.php
@@ -556,7 +556,12 @@ class CacheSessionPoolTest extends TestCase
                     'maxInUseSessions' => 1
                 ],
                 [
-                    'queue' => [],
+                    'queue' => [
+                        [
+                            'name' => 'expiresSoon',
+                            'expiration' => $time + 1500
+                        ],
+                    ],
                     'inUse' => [
                         'session' => [
                             'name' => 'session',
@@ -631,8 +636,8 @@ class CacheSessionPoolTest extends TestCase
                 [
                     'queue' => [],
                     'inUse' => [
-                        'session1' => [
-                            'name' => 'session1',
+                        'session4' => [
+                            'name' => 'session4',
                             'expiration' => $time + 3600,
                             'lastActive' => $time
                         ]


### PR DESCRIPTION
Session pool hand out sessions in LIFO order.
Replaced array_shift with array_pop. CacheSessionPool.php:619; method `getSession`