### PR TITLE
feat: resource based routing client library

### DIFF
--- a/Spanner/src/Connection/ConnectionInterface.php
+++ b/Spanner/src/Connection/ConnectionInterface.php
@@ -212,4 +212,9 @@ interface ConnectionInterface
      * @param array $args
      */
     public function partitionRead(array $args);
+
+    /**
+     * @param array $args
+     */
+    public function init(array $args);
 }

--- a/Spanner/src/Connection/Grpc.php
+++ b/Spanner/src/Connection/Grpc.php
@@ -89,6 +89,11 @@ class Grpc implements ConnectionInterface
     /**
      * @var array
      */
+    private $config;
+
+    /**
+     * @var array
+     */
     private $mutationSetters = [
         'insert' => 'setInsert',
         'update' => 'setUpdate',
@@ -153,6 +158,16 @@ class Grpc implements ConnectionInterface
 
         $config['serializer'] = $this->serializer;
         $this->setRequestWrapper(new GrpcRequestWrapper($config));
+        $this->config = $config;
+        $this->init();
+    }
+
+    /**
+     * @param array $configAdd [optional]
+     */
+    public function init($configAdd = [])
+    {
+        $config = $this->config + $configAdd;
         $grpcConfig = $this->getGaxConfig(
             ManualSpannerClient::VERSION,
             isset($config['authHttpHandler'])
@@ -1062,7 +1077,7 @@ class Grpc implements ConnectionInterface
      *
      * @return InstanceAdminClient
      */
-    private function getInstanceAdminClient()
+    private function getInstanceAdminClient($options = [])
     {
         //@codeCoverageIgnoreStart
         if ($this->instanceAdminClient) {
@@ -1070,7 +1085,10 @@ class Grpc implements ConnectionInterface
         }
         //@codeCoverageIgnoreEnd
 
-        $this->instanceAdminClient = $this->constructGapic(InstanceAdminClient::class, $this->grpcConfig);
+        $this->instanceAdminClient = $this->constructGapic(
+            InstanceAdminClient::class,
+            $options + $this->grpcConfig
+        );
 
         return $this->instanceAdminClient;
     }


### PR DESCRIPTION
**Adding Routing support based on apiEndpoint spoofing.**
Description of work on the example code:
```
$spanner = new SpannerClient();
$instance = $spanner->instance($instName);
$db = $instance->database($dbname);
$r = $db->execute('SELECT "Hello World" as test');
foreach ($r as $row) {
    print($row['test'] . PHP_EOL);
}
```
The Google-Spanner API uses lazy instantiation of the instance admin client is using for [`DatabaseAdminClient`](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Connection/Grpc.php#L1101-L1112) and [`InstanceAdminClient`](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Connection/Grpc.php#L1080-L1094) objects creation.
For this reason, these service objects are not created at the time of creation of the SpannerClient object, not at the time of creation of the connection (`Grpc` class), wrappers Instance and Database objects, but at the time of the call to `$db->execute(...)`. You must precede the execute call with the [getInstance](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Admin/Instance/V1/Gapic/InstanceAdminGapicClient.php#L682-L703) operation of the InstanceAdminClient object. For this reason, you must override the [Instance::reload()](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Instance.php#L241-L261) method in which `getInstance` is called on behalf of the object of the `InstanceAdminClient` class. To get the `endpointUris` list, you need to pass the `['fieldMask' => new FieldMask (['paths' => ['endpoint_uris']])]` parameter to the method, but this is only a matter of the first call, because. for subsequent calls to `getInstance`, it makes no sense to return this list. In addition, the environment variable specified in the task is checked, if it is and is not empty and the first call to `Instance::reload()` is detected, then the specified `FieldMask` is used in the request.
To store this list, a private `endpoints` field has been added to the Instance class, into which `null` is written in the constructor of this class. The reload method, checking for `null`, will determine whether the list was previously requested or not. The [`endpoint()`](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Instance.php#L459-L462) method is added to the Instance class - which returns the first value of this list (as written in the task), or `null` if the list is empty.
Requirements in the task:

> **premission error**
> This means the user is likely running under a custom role that doesn't have spanner.instances.get permissions. Fail with an error message making it clear that the permission must be added.

and

> **other error**
> Retry the request with fuzzed exponential backoff. Hard failure for repeated error responses.

Implemented in the [`ExponentialBackoff` class](https://github.com/q-logic/google-cloud-php/blob/endpoint/Core/src/ExponentialBackoff.php) itself ([GrpcRequestWrapper::send](https://github.com/q-logic/google-cloud-php/blob/endpoint/Core/src/GrpcRequestWrapper.php#L123)).

When the list is defined, you need to bind the result of calling `Instance::endpoint()` (if it did not return `null`) to the existing connection (Grpc class) as `apiEndpoint`. But there are no similar methods in this class. It is not possible to change the utility classes [DatabaseAdminClient](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Admin/Database/V1/Gapic/DatabaseAdminGapicClient.php) and [InstanceAdminClient](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Admin/Instance/V1/Gapic/InstanceAdminGapicClient.php) through which operations are performed, because they are GENERATED CODE. There is an option to add a [method](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Connection/Grpc.php#L168) to the Grpc class to reinitialize these classes. To do this, save the [`$options`](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Connection/Grpc.php#L161) class with which the object was created in the class itself and select the [init method](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Connection/Grpc.php#L168) from the constructor, which will create the service objects of the `DatabaseAdminClient` and `InstanceAdminClient` classes, this method accepts changes in the settings but uses the previously saved settings specified when creating the Grpc object.
Thus, after receiving `Instance::endpoint()` of a non-empty value, it is enough to call the [`Grpc::init` method and pass this value to it](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Instance.php#L256). Then all requests to the server will go through the specified `apiEndpoint`. To work correctly with the Grpc class, you need to [add a new init method to ConnectionInterface](https://github.com/q-logic/google-cloud-php/blob/endpoint/Spanner/src/Connection/ConnectionInterface.php#L219) as well.