### PR TITLE
feat: resource based routing client library in SpannerClient

### DIFF
--- a/Spanner/src/Instance.php
+++ b/Spanner/src/Instance.php
@@ -143,12 +143,29 @@ class Instance
         $returnInt64AsObject = false,
         array $info = []
     ) {
-        $this->connection = $connection;
         $this->projectId = $projectId;
         $this->name = $this->fullyQualifiedInstanceName($name, $projectId);
         $this->returnInt64AsObject = $returnInt64AsObject;
         $this->info = $info;
+        $this->connectionUpdate($connection, $lroConnection, $lroCallables);
+    }
 
+    /**
+     * Update gRPC connection, LongRunningConnection and array lroCallables in this object
+     * @param ConnectionInterface $connection gRPC connection.
+     * @param LongRunningConnectionInterface $lroConnection The LRO Connection.
+     * @param array $lroCallables An collection of form [(string) typeUrl, (callable) callable]
+     *        providing a function to invoke when an operation completes. The
+     *        callable Type should correspond to an expected value of
+     *        operation.metadata.typeUrl.
+     *
+     *  */
+    public function connectionUpdate(
+        ConnectionInterface $connection,
+        LongRunningConnectionInterface $lroConnection,
+        array $lroCallables
+    ) {
+        $this->connection = $connection;
         $this->setLroProperties($lroConnection, $lroCallables, $this->name);
     }
 

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -382,7 +382,15 @@ class SpannerClient
         ) {
             if (!isset($this->endpoints[$instanceObject->name()])) {
                 $instanceInfo = $instanceObject->info([
-                    'fieldMask' => new FieldMask(['paths' => ['endpoint_uris']])
+                    'fieldMask' => new FieldMask(['paths' => [
+                        'name',
+                        'config',
+                        'display_name',
+                        'node_count',
+                        'state',
+                        'labels',
+                        'endpoint_uris'
+                    ]])
                 ]);
                 $this->endpoints[$instanceObject->name()] = $instanceInfo['endpointUris'];
             }


### PR DESCRIPTION
### Description of changes

**Private fields added to SpannerClient class**
    • [`$config`](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR100) - to save the settings passed as a parameter to the constructor;
    • [`$endpoint`](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR105) - to store as an associative array of endpoint_uris lists for each instance-name;

**Three private methods have been added to the `SpannerClient` class:**
    • [`createConnection`](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR175) to create a gRPC connection based on the options passed [to the constructor](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR156) and stored in it.
    • [`createLroProperties`](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR192) to create LongRunningConnection, $lroCallables and $resource based on gRPC connection.
    • [`endpoint()`](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR413) to return the first apiEndpoint from the list corresponding to the full name of instance, or null if this list is absent or empty.

**In the same class (SpannerClient) modified:**
    • a [constructor](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR155-R161) that now calls `createConnection` and `createLroProperties` and saves the results as before in their private fields.
    • [`instance`](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR368) to get the endpoint_uris list if apiEndpoint was not set in the SpannerClient constructor, if the environment variable allows routing. This list, if requested, is used to create a new connection, LongRunningConnection and $lroCallables which are set for this instance.

**To Instance class:**
    • added [`connectionUpdate`](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-ec4278e0a28a51913d706fdb220a640dR163) method to set connection, LongRunningConnection and $lroCallables
    • The [constructor has been changed](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-ec4278e0a28a51913d706fdb220a640dR150) so as not to duplicate the code and use this new method.

### How it should work

When creating an Instance object using the `$spanner->instance ('my-instance');` method;
if necessary [`getInstance`](https://github.com/q-logic/google-cloud-php/blob/7db8f7a23a679b60abda324ddf68614a7c0ffab6/Spanner/src/Instance.php#L253) is refilled (via request [`$instance->info(..)`](https://github.com/q-logic/google-cloud-php/blob/7db8f7a23a679b60abda324ddf68614a7c0ffab6/Spanner/src/Instance.php#L201)) with [`FieldMask`](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR384-R387). This call should return the endpoint_uris list. This list is stored in the associative private array `$endpoint` of the SpannerClient object (key: full name instance; value - list endpoint_uris). If the list for the given instance name is not empty, then the new SpannerClient::endpoint method will return the first element from the list. Based on the returned value, a gRPC connection is created [using the new `SpannerClient::createConnection` method (with apiEndpoint parameter) and the properties for `LROTrait::setLroProperties` using the new `SpannerClient::createLroProperties` method](https://github.com/q-logic/google-cloud-php/pull/4/files#diff-fbcc06d551e59c43ae44dc8f92b3f84fR390-R394). The resulting values ​​are set only in the Instance object by the new `connectionUpdate` method. If `SpannerClient::endpoint` returns null, no changes are made to the Instance object.
Further, all requests using this instance will pass using the `apiEndpoint` that was specified to connection.

**Routing is used when the following conditions are met:**

1. `GOOGLE_CLOUD_ENABLE_RESOURCE_BASED_ROUTING` environment variable set and not empty
2. if `apiEndpoint` was not specified when creating the SpannerClient object

If all this is done and it is found that for this instance-name there is already an endpoint_uris list, then the list is not requested. If there is no list for instance-name in the list of SpannerClient::endpoints, a `getInstance` request is executed (via the request `$instance->info(..)` with `FieldMask`) and the resulting list is saved in `SpannerClient::endpoints` under the name instance-name.