### PR TITLE
feat: resource based routing client library. (in Grpc)

### DIFF
--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -141,6 +141,12 @@ class SpannerClient
             'projectIdRequired' => true
         ];
 
+        if ((false !== ($routingEnv = getenv('GOOGLE_CLOUD_ENABLE_RESOURCE_BASED_ROUTING'))) &&
+            !empty($routingEnv) &&
+            ('false' != strtolower($routingEnv))
+        ) {
+            $config['enableCaching'] = true;
+        }
         $this->connection = new Grpc($this->configureAuthentication($config));
         $this->returnInt64AsObject = $config['returnInt64AsObject'];
 

--- a/Spanner/src/SpannerClient.php
+++ b/Spanner/src/SpannerClient.php
@@ -141,12 +141,8 @@ class SpannerClient
             'projectIdRequired' => true
         ];
 
-        if ((false !== ($routingEnv = getenv('GOOGLE_CLOUD_ENABLE_RESOURCE_BASED_ROUTING'))) &&
-            !empty($routingEnv) &&
-            ('false' != strtolower($routingEnv))
-        ) {
-            $config['enableCaching'] = true;
-        }
+        $config['enableCaching'] = 'true' == strtolower(getenv('GOOGLE_CLOUD_ENABLE_RESOURCE_BASED_ROUTING'));
+
         $this->connection = new Grpc($this->configureAuthentication($config));
         $this->returnInt64AsObject = $config['returnInt64AsObject'];
 


### PR DESCRIPTION
### Caching of a GAX data client into a client-pool (dictionary) in Grpc.php file.

##### Changes to `Grpc.php` file

- New fields

private `$spannerClients` hash (endpoint_uri => spannerClient)

private `$endpointUris` has (instanceId => endpointUri)

private `$enableResourceCaching` (bool)

- new methods

private `endpoint($instanceName)` Return endpoint for the specified instance, or null if the list for this instance is empty.

private `getSpannerClient($instanceName = null)` lazy instantiation of the spanner client. If routing is enabled, a SpannerClient is returned for a specific instanceName with a binding in the connection of a specific endpoint. If the endpoint list is not requested, a request is first made for this instanceName.

- Changes:

`getInstance` – add support `FieldMask`
call-methods. Change `$this->spannerClient`  to `$this->getSpannerClient($intanceName)` where `$intanceName` parsed from database name for methods: `createSession`, `createSessionAsync`, `batchCreateSessions`; from session for other methods. 

call-methods:
`createSession`
`createSessionAsync`
`batchCreateSessions`
`getSession`
`deleteSessions`
`deleteSessionAsync`
`executeStreamingSql`
`streamingRead`
`executeBatchDml`
`beginTransaction`
`commit`
`rollback`
`partitionQuery`
`partitionRead`


##### Changes to `SpannerClient.php` file 

Contruct Fuction reads  `"GOOGLE_CLOUD_ENABLE_RESOURCE_BASED_ROUTING"` environment variable, then Contruct Fuction creates Grpc with the flag: $config['enableCaching'] = true 
Contruct Fuction checks that the status of `"GOOGLE_CLOUD_ENABLE_RESOURCE_BASED_ROUTING"` environment variable is not empty and not False